### PR TITLE
Link from Debug Mode to Application Errors

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -143,6 +143,8 @@ There are more parameters that are explained in the :ref:`server` docs.
    allows the execution of arbitrary code. This makes it a major security risk
    and therefore it **must never be used on production machines**.
 
+Want to just log errors and stack traces? See :ref:`application-errors`.
+
 Screenshot of the debugger in action:
 
 .. image:: _static/debugger.png


### PR DESCRIPTION
As a new user, I found that errors / stack traces were being swallowed. I searched for 'debug' in the documentation and found the Debug Mode section.

What I really wanted to know was how logging worked; it took me ages to find out because other frameworks (e.g. Rails) just calls this debugging.

This pull request adds a reference to the documentation that I think will help other people in this situation.