### PR TITLE
Handle a single unusual argument in jsonify

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -102,6 +102,9 @@ JSON Security
    with the builtin constructor of ``Array`` which closes this particular
    attack vector.
 
+   To disable this security check, set JSONIFY_ARRAY_SECURITY = False in
+   your config file.
+
 JSON itself is a high-level serialization format, so there is barely
 anything that could cause security problems, right?  You can't declare
 recursive structures that could cause problems and the only thing that

--- a/flask/app.py
+++ b/flask/app.py
@@ -297,6 +297,7 @@ class Flask(_PackageBoundObject):
         'JSON_AS_ASCII':                        True,
         'JSON_SORT_KEYS':                       True,
         'JSONIFY_PRETTYPRINT_REGULAR':          True,
+        'JSONIFY_ARRAY_SECURITY':               True,
         'TEMPLATES_AUTO_RELOAD':                True,
     })
 

--- a/flask/json.py
+++ b/flask/json.py
@@ -248,8 +248,8 @@ def jsonify(*args, **kwargs):
 
     serialized = dumps(data, indent=indent)
 
-    if current_app.config['JSONIFY_ARRAY_SECURITY'] and serialized.startswith('['):
-        raise ValueError, ARRAY_SECURITY_MESSAGE
+    if current_app.config['JSONIFY_ARRAY_SECURITY'] and serialized[0] == '[':
+        raise ValueError(ARRAY_SECURITY_MESSAGE)
 
     return current_app.response_class(serialized,
         mimetype='application/json')

--- a/flask/json.py
+++ b/flask/json.py
@@ -235,7 +235,7 @@ def jsonify(*args, **kwargs):
        and not request.is_xhr:
         indent = 2
 
-    if len(args) == 1 and len(kwargs) == 0:
+    if len(args) == 1 and not kwargs:
         data = args[0]
     else:
         data = dict(*args, **kwargs)

--- a/flask/json.py
+++ b/flask/json.py
@@ -234,7 +234,13 @@ def jsonify(*args, **kwargs):
     if current_app.config['JSONIFY_PRETTYPRINT_REGULAR'] \
        and not request.is_xhr:
         indent = 2
-    return current_app.response_class(dumps(dict(*args, **kwargs),
+
+    if len(args) == 1 and len(kwargs) == 0:
+        data = args[0]
+    else:
+        data = dict(*args, **kwargs)
+
+    return current_app.response_class(dumps(data,
         indent=indent),
         mimetype='application/json')
 

--- a/flask/json.py
+++ b/flask/json.py
@@ -198,6 +198,12 @@ def htmlsafe_dump(obj, fp, **kwargs):
     fp.write(unicode(htmlsafe_dumps(obj, **kwargs)))
 
 
+ARRAY_SECURITY_MESSAGE = """\
+JSON Responses with arrays at the top level open up an attack vector in some browsers.
+For more information, see: http://flask.pocoo.org/docs/security/#json-security
+"""
+
+
 def jsonify(*args, **kwargs):
     """Creates a :class:`~flask.Response` with the JSON representation of
     the given arguments with an `application/json` mimetype.  The arguments
@@ -240,8 +246,12 @@ def jsonify(*args, **kwargs):
     else:
         data = dict(*args, **kwargs)
 
-    return current_app.response_class(dumps(data,
-        indent=indent),
+    serialized = dumps(data, indent=indent)
+
+    if current_app.config['JSONIFY_ARRAY_SECURITY'] and serialized.startswith('['):
+        raise ValueError, ARRAY_SECURITY_MESSAGE
+
+    return current_app.response_class(serialized,
         mimetype='application/json')
 
 


### PR DESCRIPTION
I ran into this issue today, googled it, and found [someone else having the same issue](http://stackoverflow.com/questions/20668883/flask-jsonify-object-is-not-iterable).

If you're using the JSON Encoder in Overholt, you may notice that passing one of your models to jsonify does not work.  It says "object is not iterable", even though your custom json encoder will turn it into an iterable in a moment.  This is because Flask is trying to make it into a dict before that can happen.

This patch fixes this case.  Also it allows you to return other legitimate singular json values such as integers and strings.  Hopefully this doesn't raise any security issues.  If it does, someone else may wish to handle this more carefully.