### PR TITLE
Include backend argument when instantiating Celery

### DIFF
--- a/docs/patterns/celery.rst
+++ b/docs/patterns/celery.rst
@@ -36,7 +36,7 @@ This is all that is necessary to properly integrate Celery with Flask::
     from celery import Celery
 
     def make_celery(app):
-        celery = Celery(app.import_name, broker=app.config['CELERY_BROKER_URL'])
+        celery = Celery(app.import_name, backend="redis", broker=app.config['CELERY_BROKER_URL'])
         celery.conf.update(app.config)
         TaskBase = celery.Task
         class ContextTask(TaskBase):


### PR DESCRIPTION
Not including the backend argument can lead to AttributeError: DisabledBackend object has no attribute for '_get_task_meta_for'. See e.g., http://stackoverflow.com/questions/23215311/celery-with-rabbitmq-attributeerror-disabledbackend-object-has-no-attribute.

At the same time, including the backend argument doesn't seem to harm anything else.