### PR TITLE
Fixed and intuitivized exception handling

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1205,7 +1205,11 @@ class Flask(_PackageBoundObject):
         :type code_or_exception: int|T<=Exception
         :type f: callable
         """
-        assert not isinstance(code_or_exception, HTTPException)  # old broken behavior
+        if isinstance(code_or_exception, HTTPException):  # old broken behavior
+            raise ValueError(
+                'Tried to register a handler for an exception instance {0!r}. '
+                'Handlers can only be registered for exception classes or HTTP error codes.'
+                .format(code_or_exception))
         
         code = code_or_exception
         is_code = isinstance(code_or_exception, integer_types)

--- a/flask/app.py
+++ b/flask/app.py
@@ -65,16 +65,6 @@ def setupmethod(f):
     return update_wrapper(wrapper_func, f)
 
 
-def get_http_code(error_class_or_instance):
-    if (
-        isinstance(error_class_or_instance, HTTPException) or
-        isinstance(error_class_or_instance, type) and
-        issubclass(error_class_or_instance, HTTPException)
-    ):
-        return error_class_or_instance.code
-    return None
-
-
 class ExceptionHandlerDict(Mapping):
     """A dict storing exception handlers or falling back to the default ones
     
@@ -93,7 +83,8 @@ class ExceptionHandlerDict(Mapping):
         else:
             self.fallback = {}
     
-    def get_class(self, exc_class_or_code):
+    @staticmethod
+    def get_class(exc_class_or_code):
         if isinstance(exc_class_or_code, integer_types):
             # ensure that we register only exceptions as keys
             exc_class = default_exceptions[exc_class_or_code]

--- a/flask/app.py
+++ b/flask/app.py
@@ -1080,7 +1080,7 @@ class Flask(_PackageBoundObject):
 
     @staticmethod
     def _get_exc_class_and_code(exc_class_or_code):
-        """ensure that we register only exceptions as handler keys"""
+        """Ensure that we register only exceptions as handler keys"""
         if isinstance(exc_class_or_code, integer_types):
             exc_class = default_exceptions[exc_class_or_code]
         else:
@@ -1412,15 +1412,15 @@ class Flask(_PackageBoundObject):
         """
         exc_class, code = self._get_exc_class_and_code(type(e))
         
-        def find_superclass(d):
-            if not d:
+        def find_superclass(handler_map):
+            if not handler_map:
                 return None
-            for superclass in exc_class.mro():
+            for superclass in exc_class.__mro__:
                 if superclass is BaseException:
                     return None
-                handler = d.get(superclass)
+                handler = handler_map.get(superclass)
                 if handler is not None:
-                    d[exc_class] = handler  # cache for next time exc_class is raised
+                    handler_map[exc_class] = handler  # cache for next time exc_class is raised
                     return handler
             return None
         

--- a/flask/app.py
+++ b/flask/app.py
@@ -1211,21 +1211,7 @@ class Flask(_PackageBoundObject):
                 'Handlers can only be registered for exception classes or HTTP error codes.'
                 .format(code_or_exception))
         
-        code = code_or_exception
-        is_code = isinstance(code_or_exception, integer_types)
-        if not is_code:
-            if issubclass(code_or_exception, HTTPException):
-                code = code_or_exception.code
-            else:
-                code = None
-        
         handlers = self.error_handler_spec.setdefault(key, ExceptionHandlerDict(self, key))
-        
-        if is_code:
-            # TODO: why is this?
-            assert code != 500 or key is None, \
-                'It is currently not possible to register a 500 internal ' \
-                'server error on a per-blueprint level.'
         
         handlers[code_or_exception] = f
 
@@ -1551,7 +1537,7 @@ class Flask(_PackageBoundObject):
         exc_type, exc_value, tb = sys.exc_info()
 
         got_request_exception.send(self, exception=e)
-        handler = self.error_handler_spec[None].get(500)
+        handler = self._find_error_handler(InternalServerError())
 
         if self.propagate_exceptions:
             # if we want to repropagate the exception, we can attempt to

--- a/tests/test_user_error_handler.py
+++ b/tests/test_user_error_handler.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+from werkzeug.exceptions import Forbidden, InternalServerError
+import flask
+
+
+def test_error_handler_subclass():
+	app = flask.Flask(__name__)
+
+	class ParentException(Exception):
+		pass
+
+	class ChildExceptionUnregistered(ParentException):
+		pass
+
+	class ChildExceptionRegistered(ParentException):
+		pass
+
+	@app.errorhandler(ParentException)
+	def parent_exception_handler(e):
+		assert isinstance(e, ParentException)
+		return 'parent'
+
+	@app.errorhandler(ChildExceptionRegistered)
+	def child_exception_handler(e):
+		assert isinstance(e, ChildExceptionRegistered)
+		return 'child-registered'
+
+	@app.route('/parent')
+	def parent_test():
+		raise ParentException()
+
+	@app.route('/child-unregistered')
+	def unregistered_test():
+		raise ChildExceptionUnregistered()
+
+	@app.route('/child-registered')
+	def registered_test():
+		raise ChildExceptionRegistered()
+
+
+	c = app.test_client()
+
+	assert c.get('/parent').data == b'parent'
+	assert c.get('/child-unregistered').data == b'parent'
+	assert c.get('/child-registered').data == b'child-registered'
+
+
+def test_error_handler_http_subclass():
+	app = flask.Flask(__name__)
+
+	class ForbiddenSubclassRegistered(Forbidden):
+		pass
+
+	class ForbiddenSubclassUnregistered(Forbidden):
+		pass
+
+	@app.errorhandler(403)
+	def code_exception_handler(e):
+		assert isinstance(e, Forbidden)
+		return 'forbidden'
+
+	@app.errorhandler(ForbiddenSubclassRegistered)
+	def subclass_exception_handler(e):
+		assert isinstance(e, ForbiddenSubclassRegistered)
+		return 'forbidden-registered'
+
+	@app.route('/forbidden')
+	def forbidden_test():
+		raise Forbidden()
+
+	@app.route('/forbidden-registered')
+	def registered_test():
+		raise ForbiddenSubclassRegistered()
+
+	@app.route('/forbidden-unregistered')
+	def unregistered_test():
+		raise ForbiddenSubclassUnregistered()
+
+
+	c = app.test_client()
+
+	assert c.get('/forbidden').data == b'forbidden'
+	assert c.get('/forbidden-unregistered').data == b'forbidden'
+	assert c.get('/forbidden-registered').data == b'forbidden-registered'
+
+
+def test_error_handler_blueprint():
+	bp = flask.Blueprint('bp', __name__)
+	
+	@bp.errorhandler(500)
+	def bp_exception_handler(e):
+		return 'bp-error'
+	
+	@bp.route('/error')
+	def bp_test():
+		raise InternalServerError()
+	
+	app = flask.Flask(__name__)
+	
+	@app.errorhandler(500)
+	def app_exception_handler(e):
+		return 'app-error'
+	
+	@app.route('/error')
+	def app_test():
+		raise InternalServerError()
+	
+	app.register_blueprint(bp, url_prefix='/bp')
+	
+	c = app.test_client()
+	
+	assert c.get('/error').data == b'app-error'
+	assert c.get('/bp/error').data == b'bp-error'


### PR DESCRIPTION
abandoning pull request #1281 for this.

the rationale for this is to

1. fix some logic flaws
2. make errorhandlers more intuitive by making them rely on exception hierarchy instead of registration order
3. Enable 500 handlers on blueprint level

and all this while without breaking compatibility in not-already-broken usecases (which rely on the logic flaws i fixed)

TODO:

1. bake this into some tests as well
2. one error says

    > It is currently not possible to register a 500 internal server error on a per-blueprint level.

    why is this?