### PR TITLE
register user errorhandler in the right order

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1151,13 +1151,12 @@ class Flask(_PackageBoundObject):
             return
 
         error_builder = []
-        found = -1
         for i, (error, _) in enumerate(registered_errors):
             if issubclass(error, exception):
                 error_builder.extend(registered_errors[0:i + 1])
                 found = i
                 break
-        if found == -1:
+        else:
             registered_errors.insert(0, (exception, f))
             return
 

--- a/flask/app.py
+++ b/flask/app.py
@@ -1141,8 +1141,35 @@ class Flask(_PackageBoundObject):
                 'server error on a per-blueprint level.'
             self.error_handler_spec.setdefault(key, {})[code_or_exception] = f
         else:
-            self.error_handler_spec.setdefault(key, {}).setdefault(None, []) \
-                .append((code_or_exception, f))
+            self._append_error_handler(key, code_or_exception, f)
+
+    def _append_error_handler(self, key, exception, f):
+        registered_errors = self.error_handler_spec.setdefault(key, {}).\
+            setdefault(None, [])
+        if exception in dict(registered_errors):
+            # do not register the same exception to another handler
+            return
+
+        error_builder = []
+        found = -1
+        for i, (error, _) in enumerate(registered_errors):
+            if issubclass(error, exception):
+                error_builder.extend(registered_errors[0:i + 1])
+                found = i
+                break
+        if found == -1:
+            registered_errors.insert(0, (exception, f))
+            return
+
+        tailed_errors = registered_errors[found + 1:]
+        for i, (error, _) in enumerate(tailed_errors):
+            if issubclass(exception, error):
+                error_builder.extend(tailed_errors[0:i])
+                error_builder.append((exception, f))
+                error_builder.extend(tailed_errors[i:])
+                self.registered_errors = error_builder
+                return
+        registered_errors.append((exception, f))
 
     @setupmethod
     def template_filter(self, name=None):

--- a/flask/app.py
+++ b/flask/app.py
@@ -1166,7 +1166,7 @@ class Flask(_PackageBoundObject):
                 error_builder.extend(tailed_errors[0:i])
                 error_builder.append((exception, f))
                 error_builder.extend(tailed_errors[i:])
-                self.registered_errors = error_builder
+                self.error_handler_spec[key][None] = error_builder
                 return
         registered_errors.append((exception, f))
 

--- a/tests/test_user_error_handler.py
+++ b/tests/test_user_error_handler.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+import itertools
+import flask
+
+
+def test_register_error_handler_the_right_order():
+    class BasicException(Exception):
+        pass
+
+    class E1(BasicException):
+        pass
+
+    class E2(E1):
+        pass
+
+    class E3(E2):
+        pass
+
+    class E4(E3):
+        pass
+
+    app = flask.Flask(__name__)
+
+    def f(e):
+        return 'boom'
+
+    for e1, e2, e3, e4, e in itertools.permutations(
+            (E1, E2, E3, E4, BasicException)):
+        app.register_error_handler(e1, f)
+        app.register_error_handler(e2, f)
+        app.register_error_handler(e3, f)
+        app.register_error_handler(e4, f)
+        app.register_error_handler(e, f)
+        error_handlers = app.error_handler_spec[None][None]
+        assert error_handlers[0] == (E4, f)
+        assert error_handlers[1] == (E3, f)
+        assert error_handlers[2] == (E2, f)
+        assert error_handlers[3] == (E1, f)
+        assert error_handlers[4] == (BasicException, f)
+        error_handlers = []
+
+
+def test_error_handler_call_order():
+    app = flask.Flask(__name__)
+
+    class ParentException(Exception):
+        pass
+
+    class ChildException(ParentException):
+        pass
+
+    @app.errorhandler(ParentException)
+    def my_decorator_exception_handler(e):
+        assert isinstance(e, ParentException)
+        return 'parent'
+
+    @app.errorhandler(ChildException)
+    def my_function_exception_handler(e):
+        assert isinstance(e, ChildException)
+        return 'child'
+
+    @app.route('/parent')
+    def blue_deco_test():
+        raise ParentException()
+
+    @app.route('/child')
+    def blue_func_test():
+        raise ChildException()
+
+
+    c = app.test_client()
+
+    assert c.get('/parent').data == b'parent'
+    assert c.get('/child').data == b'child'

--- a/tests/test_user_error_handler.py
+++ b/tests/test_user_error_handler.py
@@ -37,7 +37,7 @@ def test_register_error_handler_the_right_order():
         assert error_handlers[2] == (E2, f)
         assert error_handlers[3] == (E1, f)
         assert error_handlers[4] == (BasicException, f)
-        error_handlers = []
+        app.error_handler_spec[None][None] = []
 
 
 def test_error_handler_call_order():


### PR DESCRIPTION
solved the problem proposed by  #1291 in a lighter way,
thus determining the `exception  hierarchy` at app setup time instead of running time.