### PR TITLE
Allow to know about Blueprints registeration state

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -118,6 +118,20 @@ On top of that you can register blueprints multiple times though not every
 blueprint might respond properly to that.  In fact it depends on how the
 blueprint is implemented if it can be mounted more than once.
 
+You can hint other developers on your implementation with the ``register_once``
+parameter::
+
+  from flask import Flask, Blueprint
+
+  blueprint = Blueprint('blueprint', __name__, register_once=True)
+  app = Flask(__name__)
+
+  assert not blueprint.is_registered
+  app.register_blueprint(blueprint)
+  assert blueprint.is_registered
+
+  app.register_blueprint(blueprint) # Raise a warning
+
 Blueprint Resources
 -------------------
 

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -9,6 +9,8 @@
     :license: BSD, see LICENSE for more details.
 """
 
+import warnings
+
 import pytest
 
 import flask
@@ -575,3 +577,39 @@ def test_add_template_test_with_name_and_template():
         return flask.render_template('template_test.html', value=False)
     rv = app.test_client().get('/')
     assert b'Success!' in rv.data
+
+def test_blueprint_is_registered():
+    blueprint = flask.Blueprint('blueprint', __name__)
+    other_blueprint = flask.Blueprint('other', __name__)
+
+    assert not blueprint.is_registered
+    assert not other_blueprint.is_registered
+
+    app = flask.Flask(__name__)
+    app.register_blueprint(blueprint)
+    assert blueprint.is_registered
+    assert not other_blueprint.is_registered
+
+def test_blueprint_can_be_registered_more_than_once():
+    blueprint = flask.Blueprint('blueprint', __name__)
+    app = flask.Flask(__name__)
+
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        app.register_blueprint(blueprint)
+        app.register_blueprint(blueprint)
+
+        assert len(w) == 0
+
+def test_blueprint_raise_warning_if_registered_twice():
+    blueprint = flask.Blueprint('blueprint', __name__, register_once=True)
+    app = flask.Flask(__name__)
+
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        app.register_blueprint(blueprint)
+        app.register_blueprint(blueprint)
+
+        assert len(w) == 1


### PR DESCRIPTION
This pull-request permit to know if a blueprint has already been registered or not (very usefull for extensions).

It also remove the never used (and misleading) ``Blueprint._got_registered_once`` attribute.

Now, you can write:
```python
blueprint = Blueprint('blueprint', __name__)

assert not blueprint.is_registered

app = Flask(__name__)
app.register_blueprint(blueprint)
assert blueprint.is_registered
```

It also allows to specify than a blueprint can't be registered twice with the ``register_once`` constructor kwarg:
```python
blueprint = Blueprint('blueprint', __name__, register_once=True)
app = Flask(__name__)
app.register_blueprint(blueprint)
app.register_blueprint(blueprint) # Raise a warning
```