### PR TITLE
Added missing import.

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -276,7 +276,7 @@ having to change some code.  This can trivially be accomplished with
 hooking the :data:`flask.appcontext_pushed` signal::
 
     from contextlib import contextmanager
-    from flask import appcontext_pushed
+    from flask import appcontext_pushed, g
 
     @contextmanager
     def user_set(app, user):


### PR DESCRIPTION
As this specific code block lists imports in general and an import from the `flask` package specifically, it should also include `g` for the sake of completeness.