### PR TITLE
Replace TextField with StringField in registration page example

### DIFF
--- a/docs/patterns/wtforms.rst
+++ b/docs/patterns/wtforms.rst
@@ -26,11 +26,11 @@ The Forms
 
 This is an example form for a typical registration page::
 
-    from wtforms import Form, BooleanField, TextField, PasswordField, validators
+    from wtforms import Form, BooleanField, StringField, PasswordField, validators
 
     class RegistrationForm(Form):
-        username = TextField('Username', [validators.Length(min=4, max=25)])
-        email = TextField('Email Address', [validators.Length(min=6, max=35)])
+        username = StringField('Username', [validators.Length(min=4, max=25)])
+        email = StringField('Email Address', [validators.Length(min=6, max=35)])
         password = PasswordField('New Password', [
             validators.Required(),
             validators.EqualTo('confirm', message='Passwords must match')


### PR DESCRIPTION
Replaces TextField with StringField for the username and email. Per http://wtforms.readthedocs.org/en/latest/whats_new.html#deprecated-api-s TextField has been deprecated in WTForms.