### PR TITLE
Clarify contents of request properties.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -92,24 +92,24 @@ Incoming Request Data
    .. attribute:: base_url
    .. attribute:: url_root
 
-      Provides different ways to look at the current URL.  Imagine your
-      application is listening on the following URL::
+      Provides different ways to look at the current `IRI<http://tools.ietf.org/html/rfc3987>`_.  Imagine your
+      application is listening on the following IRI::
 
           http://www.example.com/myapplication
 
-      And a user requests the following URL::
+      And a user requests the following IRI::
 
-          http://www.example.com/myapplication/page.html?x=y
+          http://www.example.com/myapplication/日本/page.html?x=y
 
       In this case the values of the above mentioned attributes would be
       the following:
 
       ============= ======================================================
-      `path`        ``/page.html``
-      `full_path`   ``/page.html?x=y``
+      `path`        ``/日本/page.html``
+      `full_path`   ``/日本/page.html?x=y``
       `script_root` ``/myapplication``
-      `base_url`    ``http://www.example.com/myapplication/page.html``
-      `url`         ``http://www.example.com/myapplication/page.html?x=y``
+      `base_url`    ``http://www.example.com/myapplication/日本/page.html``
+      `url`         ``http://www.example.com/myapplication/日本/page.html?x=y``
       `url_root`    ``http://www.example.com/myapplication/``
       ============= ======================================================
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -92,7 +92,8 @@ Incoming Request Data
    .. attribute:: base_url
    .. attribute:: url_root
 
-      Provides different ways to look at the current `IRI<http://tools.ietf.org/html/rfc3987>`_.  Imagine your
+      Provides different ways to look at the current
+      `IRI<http://tools.ietf.org/html/rfc3987>`_.  Imagine your
       application is listening on the following application root::
 
           http://www.example.com/myapplication

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -93,13 +93,13 @@ Incoming Request Data
    .. attribute:: url_root
 
       Provides different ways to look at the current `IRI<http://tools.ietf.org/html/rfc3987>`_.  Imagine your
-      application is listening on the following IRI::
+      application is listening on the following application root::
 
           http://www.example.com/myapplication
 
-      And a user requests the following IRI::
+      And a user requests the following URI::
 
-          http://www.example.com/myapplication/π/page.html?x=y
+          http://www.example.com/myapplication/%CF%80/page.html?x=y
 
       In this case the values of the above mentioned attributes would be
       the following:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -99,18 +99,18 @@ Incoming Request Data
 
       And a user requests the following IRI::
 
-          http://www.example.com/myapplication/日本/page.html?x=y
+          http://www.example.com/myapplication/π/page.html?x=y
 
       In this case the values of the above mentioned attributes would be
       the following:
 
       ============= ======================================================
-      `path`        ``/日本/page.html``
-      `full_path`   ``/日本/page.html?x=y``
-      `script_root` ``/myapplication``
-      `base_url`    ``http://www.example.com/myapplication/日本/page.html``
-      `url`         ``http://www.example.com/myapplication/日本/page.html?x=y``
-      `url_root`    ``http://www.example.com/myapplication/``
+      `path`        ``u'/π/page.html'``
+      `full_path`   ``u'/π/page.html?x=y'``
+      `script_root` ``u'/myapplication'``
+      `base_url`    ``u'http://www.example.com/myapplication/π/page.html'``
+      `url`         ``u'http://www.example.com/myapplication/π/page.html?x=y'``
+      `url_root`    ``u'http://www.example.com/myapplication/'``
       ============= ======================================================
 
    .. attribute:: is_xhr


### PR DESCRIPTION
Change URL to IRI and update examples to include extended characters. See also this question on stackoverflow.com: http://stackoverflow.com/questions/28056959/in-python-flask-how-to-access-complete-raw-url-prior-to-un-escaping/28058628#28058628