### PR TITLE
It resolves problems with blueprints and url_prefix "/"

### DIFF
--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -147,7 +147,10 @@ class Blueprint(_PackageBoundObject):
         self._got_registered_once = True
         state = self.make_setup_state(app, options, first_registration)
         if self.has_static_folder:
-            state.add_url_rule(self.static_url_path + '/<path:filename>',
+            rule = self.static_url_path
+            if self.url_prefix == '/':
+                rule = self.name + rule
+            state.add_url_rule(rule + '/<path:filename>',
                                view_func=self.send_static_file,
                                endpoint='static')
 


### PR DESCRIPTION
Issue #348 

I want to separate an app with various blueprints, frontend, backend, etc.. But when I try to register my frontend blueprint with follow code, my static css, images, js don't load.
``` python
front = Blueprint('front', __name__, static_folder='static', template_folder='./templates', url_prefix='/')
```
After debugging I found the problem. It's when try to register route, it tries to register route like //static (https://github.com/mitsuhiko/flask/blob/master/flask/blueprints.py#L68)


And then when use url_for the werkzeug routing.py (https://github.com/mitsuhiko/werkzeug/blob/master/werkzeug/routing.py#L1655) resolve url_for //static/filename it found a problem beacause there are two rules like this: 
```python
[<Rule '/static/<filename>' (HEAD, OPTIONS, GET) -> static>, <Rule '//static/<filename>' (HEAD, OPTIONS, GET) -> front.static>]
```

So, a simple solution like concatenate a `blueprint.name` before url_prefix when is "/" resolve this conflict and now we can  use `url_for('front.static', filename='2.jpg')` routing resolves without problem.