### PR TITLE
Use PEP440-compatible dev version

### DIFF
--- a/flask/__init__.py
+++ b/flask/__init__.py
@@ -10,7 +10,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
-__version__ = '0.11-dev'
+__version__ = '0.11.dev0'
 
 # utilities we import from Werkzeug and Jinja2 that are unused
 # in the module but are exported as public interface.

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ class run_audit(Command):
 
 setup(
     name='Flask',
-    version='0.11-dev',
+    version='0.11.dev0',
     url='http://github.com/mitsuhiko/flask/',
     license='BSD',
     author='Armin Ronacher',


### PR DESCRIPTION
This fixes the problem of python packaging considering an installed dev version older than 0.0.