### PR TITLE
Add skip to fix unnoticed bug with import migration tool

### DIFF
--- a/scripts/flaskext_migrate.py
+++ b/scripts/flaskext_migrate.py
@@ -40,6 +40,8 @@ def fix_from_imports(red):
     from_imports = red.find_all("FromImport")
     for x, node in enumerate(from_imports):
         values = node.value
+        if len(values) < 2:
+            continue
         if (values[0].value == 'flask') and (values[1].value == 'ext'):
             # Case 1
             if len(node.value) == 3:

--- a/scripts/test_import_migration.py
+++ b/scripts/test_import_migration.py
@@ -45,7 +45,7 @@ def test_named_module_import():
     assert output == "import flask_foo as foobar"
 
 
-def test__named_from_import():
+def test_named_from_import():
     red = RedBaron("from flask.ext.foo import bar as baz")
     output = migrate.fix_tester(red)
     assert output == "from flask_foo import bar as baz"
@@ -69,3 +69,9 @@ def test_nested_function_call_migration():
     output = migrate.fix_tester(red)
     assert output == ("import flask_foo\n\n"
                       "flask_foo.bar(var)")
+
+
+def test_no_change_to_import():
+    red = RedBaron("from flask import Flask")
+    output = migrate.fix_tester(red)
+    assert output == "from flask import Flask"


### PR DESCRIPTION
See pull request #1342. Fixes logic so that imports that should not be changed are skipped, which was not happening correctly before. This was huge oversight on my part. I added a test for normal imports that shouldn't be touched.