### PR TITLE
Add exception details to response

### DIFF
--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -175,7 +175,7 @@ class Request(RequestBase):
 
         .. versionadded:: 0.8
         """
-        raise BadRequest()
+        raise BadRequest(e)
 
     def _load_form_data(self):
         RequestBase._load_form_data(self)

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -177,7 +177,7 @@ class Request(RequestBase):
         ctx = _request_ctx_stack.top
         if ctx is not None:
             if ctx.app.config.get('DEBUG', False):
-                raise BadRequest(e)
+                raise BadRequest('No JSON object could be decoded')
         raise BadRequest()
 
     def _load_form_data(self):

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -174,10 +174,11 @@ class Request(RequestBase):
 
         .. versionadded:: 0.8
         """
-        if current_app.config['DEBUG']:
-            raise BadRequest(e)
-        else:
-            raise BadRequest()
+        ctx = _request_ctx_stack.top
+        if ctx is not None:
+            if ctx.app.config.get('DEBUG', False):
+                raise BadRequest(e)
+        raise BadRequest()
 
     def _load_form_data(self):
         RequestBase._load_form_data(self)

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -13,8 +13,7 @@ from werkzeug.wrappers import Request as RequestBase, Response as ResponseBase
 from werkzeug.exceptions import BadRequest
 
 from . import json
-from .globals import _request_ctx_stack
-
+from .globals import _request_ctx_stack, current_app
 
 _missing = object()
 
@@ -175,7 +174,10 @@ class Request(RequestBase):
 
         .. versionadded:: 0.8
         """
-        raise BadRequest(e)
+        if current_app.config['DEBUG']:
+            raise BadRequest(e)
+        else:
+            raise BadRequest()
 
     def _load_form_data(self):
         RequestBase._load_form_data(self)

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -177,7 +177,7 @@ class Request(RequestBase):
         ctx = _request_ctx_stack.top
         if ctx is not None:
             if ctx.app.config.get('DEBUG', False):
-                raise BadRequest('No JSON object could be decoded')
+                raise BadRequest('Failed to decode JSON object: {}'.format(e))
         raise BadRequest()
 
     def _load_form_data(self):

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -177,7 +177,7 @@ class Request(RequestBase):
         ctx = _request_ctx_stack.top
         if ctx is not None:
             if ctx.app.config.get('DEBUG', False):
-                raise BadRequest('Failed to decode JSON object: {}'.format(e))
+                raise BadRequest('Failed to decode JSON object: {0}'.format(e))
         raise BadRequest()
 
     def _load_form_data(self):

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -13,7 +13,7 @@ from werkzeug.wrappers import Request as RequestBase, Response as ResponseBase
 from werkzeug.exceptions import BadRequest
 
 from . import json
-from .globals import _request_ctx_stack, current_app
+from .globals import _request_ctx_stack
 
 _missing = object()
 
@@ -175,9 +175,8 @@ class Request(RequestBase):
         .. versionadded:: 0.8
         """
         ctx = _request_ctx_stack.top
-        if ctx is not None:
-            if ctx.app.config.get('DEBUG', False):
-                raise BadRequest('Failed to decode JSON object: {0}'.format(e))
+        if ctx is not None and ctx.app.config.get('DEBUG', False):
+            raise BadRequest('Failed to decode JSON object: {0}'.format(e))
         raise BadRequest()
 
     def _load_form_data(self):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -49,6 +49,30 @@ class TestJSON(object):
             assert rv.mimetype == 'application/json'
             assert flask.json.loads(rv.data)['x'] == http_date(d.timetuple())
 
+    def test_post_empty_json_adds_exception_to_reponse_content_in_debug(self):
+        app = flask.Flask(__name__)
+        app.config['DEBUG'] = True
+        @app.route('/json', methods=['POST'])
+        def post_json():
+            flask.request.get_json()
+            return None
+        c = app.test_client()
+        rv = c.post('/json', data=None, content_type='application/json')
+        assert rv.status_code == 400
+        assert '<p>No JSON object could be decoded</p>' in rv.data
+
+    def test_post_empty_json_doesnt_add_exception_to_reponse_if_no_debug(self):
+        app = flask.Flask(__name__)
+        app.config['DEBUG'] = False
+        @app.route('/json', methods=['POST'])
+        def post_json():
+            flask.request.get_json()
+            return None
+        c = app.test_client()
+        rv = c.post('/json', data=None, content_type='application/json')
+        assert rv.status_code == 400
+        assert '<p>No JSON object could be decoded</p>' not in rv.data
+
     def test_json_bad_requests(self):
         app = flask.Flask(__name__)
         @app.route('/json', methods=['POST'])

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -59,7 +59,7 @@ class TestJSON(object):
         c = app.test_client()
         rv = c.post('/json', data=None, content_type='application/json')
         assert rv.status_code == 400
-        assert b'No JSON object could be decoded' in rv.data
+        assert b'Failed to decode JSON object' in rv.data
 
     def test_post_empty_json_wont_add_exception_to_response_if_no_debug(self):
         app = flask.Flask(__name__)
@@ -71,7 +71,7 @@ class TestJSON(object):
         c = app.test_client()
         rv = c.post('/json', data=None, content_type='application/json')
         assert rv.status_code == 400
-        assert b'No JSON object could be decoded' not in rv.data
+        assert b'Failed to decode JSON object' not in rv.data
 
     def test_json_bad_requests(self):
         app = flask.Flask(__name__)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -49,7 +49,7 @@ class TestJSON(object):
             assert rv.mimetype == 'application/json'
             assert flask.json.loads(rv.data)['x'] == http_date(d.timetuple())
 
-    def test_post_empty_json_adds_exception_to_reponse_content_in_debug(self):
+    def test_post_empty_json_adds_exception_to_response_content_in_debug(self):
         app = flask.Flask(__name__)
         app.config['DEBUG'] = True
         @app.route('/json', methods=['POST'])
@@ -59,9 +59,9 @@ class TestJSON(object):
         c = app.test_client()
         rv = c.post('/json', data=None, content_type='application/json')
         assert rv.status_code == 400
-        assert 'No JSON object could be decoded' in rv.data
+        assert b'No JSON object could be decoded' in rv.data
 
-    def test_post_empty_json_doesnt_add_exception_to_reponse_if_no_debug(self):
+    def test_post_empty_json_wont_add_exception_to_response_if_no_debug(self):
         app = flask.Flask(__name__)
         app.config['DEBUG'] = False
         @app.route('/json', methods=['POST'])
@@ -71,7 +71,7 @@ class TestJSON(object):
         c = app.test_client()
         rv = c.post('/json', data=None, content_type='application/json')
         assert rv.status_code == 400
-        assert 'No JSON object could be decoded' not in rv.data
+        assert b'No JSON object could be decoded' not in rv.data
 
     def test_json_bad_requests(self):
         app = flask.Flask(__name__)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -59,7 +59,7 @@ class TestJSON(object):
         c = app.test_client()
         rv = c.post('/json', data=None, content_type='application/json')
         assert rv.status_code == 400
-        assert '<p>No JSON object could be decoded</p>' in rv.data
+        assert 'No JSON object could be decoded' in rv.data
 
     def test_post_empty_json_doesnt_add_exception_to_reponse_if_no_debug(self):
         app = flask.Flask(__name__)
@@ -71,7 +71,7 @@ class TestJSON(object):
         c = app.test_client()
         rv = c.post('/json', data=None, content_type='application/json')
         assert rv.status_code == 400
-        assert '<p>No JSON object could be decoded</p>' not in rv.data
+        assert 'No JSON object could be decoded' not in rv.data
 
     def test_json_bad_requests(self):
         app = flask.Flask(__name__)


### PR DESCRIPTION
This pull request is in regards to issue #1317. I reproduced the 400 error that kenjones-cisco was talking about using this code: gist.github.com/keyanp/bc4d1a3a1e6c5cb5170a

So I took a look at making a subclass of BadRequest, but indeed this is part of Werkzeug. So instead I was thinking of adding the ValueError content to the shell console or to the response body. By just adding the exception to the response body it at least improves the 400 message and probably will make it easier to debug. The response body (which is also in the gist above) would now look like:

```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>400 Bad Request</title>
<h1>Bad Request</h1>
<p>No JSON object could be decoded</p>
```

If this isn't really that helpful perhaps I can just output the exception details to the console? Could someone point me in the direction of where in the codebase Flask handles console logging?