### PR TITLE
Add command line support for ext_migrate tool

### DIFF
--- a/scripts/test_import_migration.py
+++ b/scripts/test_import_migration.py
@@ -1,9 +1,8 @@
 # Tester for the flaskext_migrate.py module located in flask/scripts/
 #
 # Author: Keyan Pishdadian
-import pytest
 from redbaron import RedBaron
-import flaskext_migrate as migrate
+import scripts.flaskext_migrate as migrate
 
 
 def test_simple_from_import():

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
         'Jinja2>=2.4',
         'itsdangerous>=0.21',
         'click>=2.0',
-        'redbaron>=0.5',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,9 @@ setup(
         'itsdangerous>=0.21',
         'click>=2.0',
     ],
+    extras_require={
+        'redbaron': ['redbaron>=0.5'],
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
@@ -88,6 +91,6 @@ setup(
     entry_points='''
         [console_scripts]
         flask=flask.cli:main
-        ext_migrate=scripts.flaskext_migrate:fix
+        flask_ext_migrate=scripts.flaskext_migrate:fix [redbaron]
     '''
 )

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     description='A microframework based on Werkzeug, Jinja2 '
                 'and good intentions',
     long_description=__doc__,
-    packages=['flask', 'flask.ext'],
+    packages=['flask', 'flask.ext', 'scripts'],
     include_package_data=True,
     zip_safe=False,
     platforms='any',
@@ -73,6 +73,7 @@ setup(
         'Jinja2>=2.4',
         'itsdangerous>=0.21',
         'click>=2.0',
+        'redbaron>=0.5',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -88,5 +89,6 @@ setup(
     entry_points='''
         [console_scripts]
         flask=flask.cli:main
+        ext_migrate=scripts.flaskext_migrate:fix
     '''
 )


### PR DESCRIPTION
Make /scripts into package and change setup.py to allow for command line execution of the import migration tool (#1342).

While updating the docs for #1366 I realized I needed to make the import migration tool easily executed through the command line. I will wait on submitting changes to #1366 until we can decide on how to implement use of the tool.