### PR TITLE
Configure pytest's norecursedirs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ release = egg_info -RDb ''
 
 [wheel]
 universal = 1
+
+[pytest]
+norecursedirs = .* *.egg *.egg-info env* artwork docs


### PR DESCRIPTION
Skip directories which don't contain unittests and especially virtualenvs (in folders named `env*`).
Otherwise you get ugly failures when running tests because pytest descends into the virtualenv.