### PR TITLE
Add line of code required to run examples for Other Testing Tricks section

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -207,6 +207,8 @@ temporarily.  With this you can access the :class:`~flask.request`,
 :class:`~flask.g` and :class:`~flask.session` objects like in view
 functions.  Here is a full example that demonstrates this approach::
 
+    import flask
+    
     app = flask.Flask(__name__)
 
     with app.test_request_context('/?name=Peter'):


### PR DESCRIPTION
As it stated, documentation states full example that demonstrates this approach, with the way it is implemented. It requires this line of code to perform the test functions on the three examples under Other Testing Tricks.