### PR TITLE
Ignore handled exception when popping the context

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Patches and Suggestions
 - Kenneth Reitz
 - Keyan Pishdadian
 - Marian Sigler
+- Martijn Pieters
 - Matt Campell
 - Matthew Frazier
 - Michael van Tellingen

--- a/flask/app.py
+++ b/flask/app.py
@@ -38,6 +38,9 @@ from ._compat import reraise, string_types, text_type, integer_types
 # a lock used for logger initialization
 _logger_lock = Lock()
 
+# a singleton sentinel value for parameter defaults
+_sentinel = object()
+
 
 def _make_timedelta(value):
     if not isinstance(value, timedelta):
@@ -1774,7 +1777,7 @@ class Flask(_PackageBoundObject):
             self.save_session(ctx.session, response)
         return response
 
-    def do_teardown_request(self, exc=None):
+    def do_teardown_request(self, exc=_sentinel):
         """Called after the actual request dispatching and will
         call every as :meth:`teardown_request` decorated function.  This is
         not actually called by the :class:`Flask` object itself but is always
@@ -1785,7 +1788,7 @@ class Flask(_PackageBoundObject):
            Added the `exc` argument.  Previously this was always using the
            current exception information.
         """
-        if exc is None:
+        if exc is _sentinel:
             exc = sys.exc_info()[1]
         funcs = reversed(self.teardown_request_funcs.get(None, ()))
         bp = _request_ctx_stack.top.request.blueprint
@@ -1795,14 +1798,14 @@ class Flask(_PackageBoundObject):
             func(exc)
         request_tearing_down.send(self, exc=exc)
 
-    def do_teardown_appcontext(self, exc=None):
+    def do_teardown_appcontext(self, exc=_sentinel):
         """Called when an application context is popped.  This works pretty
         much the same as :meth:`do_teardown_request` but for the application
         context.
 
         .. versionadded:: 0.9
         """
-        if exc is None:
+        if exc is _sentinel:
             exc = sys.exc_info()[1]
         for func in reversed(self.teardown_appcontext_funcs):
             func(exc)

--- a/tests/test_appctx.py
+++ b/tests/test_appctx.py
@@ -78,6 +78,21 @@ def test_app_tearing_down_with_previous_exception():
 
     assert cleanup_stuff == [None]
 
+def test_app_tearing_down_with_handled_exception():
+    cleanup_stuff = []
+    app = flask.Flask(__name__)
+    @app.teardown_appcontext
+    def cleanup(exception):
+        cleanup_stuff.append(exception)
+
+    with app.app_context():
+        try:
+            raise Exception('dummy')
+        except Exception:
+            pass
+
+    assert cleanup_stuff == [None]
+
 def test_custom_app_ctx_globals_class():
     class CustomRequestGlobals(object):
         def __init__(self):

--- a/tests/test_reqctx.py
+++ b/tests/test_reqctx.py
@@ -48,6 +48,21 @@ def test_teardown_with_previous_exception():
         assert buffer == []
     assert buffer == [None]
 
+def test_teardown_with_handled_exception():
+    buffer = []
+    app = flask.Flask(__name__)
+    @app.teardown_request
+    def end_of_request(exception):
+        buffer.append(exception)
+
+    with app.test_request_context():
+        assert buffer == []
+        try:
+            raise Exception('dummy')
+        except Exception:
+            pass
+    assert buffer == [None]
+
 def test_proper_test_request_context():
     app = flask.Flask(__name__)
     app.config.update(


### PR DESCRIPTION
This is a fix for #1392; the app and request contexts should not report an exception when tearing down after an exception has already been handled in a `with` statement.