### PR TITLE
Fix Possible Typo

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1181,7 +1181,7 @@ def test_test_app_proper_environ():
 
 
 def test_exception_propagation():
-    def apprunner(configkey):
+    def apprunner(config_key):
         app = flask.Flask(__name__)
         app.config['LOGGER_HANDLER_POLICY'] = 'never'
 


### PR DESCRIPTION
Looks like that was meant to be `config_key`. It works by accident because the function is defined in the same scope as the loop that passes `config_key` to `apprunner`.