### PR TITLE
Add support for toplevel arrays

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -300,6 +300,7 @@ class Flask(_PackageBoundObject):
         'JSON_AS_ASCII':                        True,
         'JSON_SORT_KEYS':                       True,
         'JSONIFY_PRETTYPRINT_REGULAR':          True,
+        'JSONIFY_ALLOW_TOPLEVEL_ARRAY':         False,
         'TEMPLATES_AUTO_RELOAD':                None,
     })
 

--- a/flask/json.py
+++ b/flask/json.py
@@ -243,13 +243,15 @@ def jsonify(*args, **kwargs):
         indent = 2
         separators = (', ', ': ')
 
-    # Return toplevel array only when no kwargs is given
-    data = kwargs
-    if not data:
+    try:
+        data = dict(*args, **kwargs)
+    except:
         if current_app.config['JSONIFY_ALLOW_TOPLEVEL_ARRAY']:
-            data = args
+            # Return a toplevel array when converting to an object
+            # is not possible
+            data = list(*args, **kwargs)
         else:
-            raise ValueError('top-level array is not allowed')
+            raise
 
     # Note that we add '\n' to end of response
     # (see https://github.com/mitsuhiko/flask/pull/1262)

--- a/flask/json.py
+++ b/flask/json.py
@@ -222,7 +222,8 @@ def jsonify(*args, **kwargs):
             "id": 42
         }
 
-    For security reasons only objects are supported toplevel.  For more
+    For security reasons only objects are supported toplevel unless the
+    ``JSONIFY_ALLOW_TOPLEVEL_ARRAY`` config parameter is set.  For more
     information about this, have a look at :ref:`json-security`.
 
     This function's response will be pretty printed if it was not requested
@@ -242,11 +243,18 @@ def jsonify(*args, **kwargs):
         indent = 2
         separators = (', ', ': ')
 
+    # Return toplevel array only when no kwargs is given
+    data = kwargs
+    if not data:
+        if current_app.config['JSONIFY_ALLOW_TOPLEVEL_ARRAY']:
+            data = args
+        else:
+            raise ValueError('top-level array is not allowed')
+
     # Note that we add '\n' to end of response
     # (see https://github.com/mitsuhiko/flask/pull/1262)
     rv = current_app.response_class(
-        (dumps(dict(*args, **kwargs), indent=indent, separators=separators),
-         '\n'),
+        (dumps(data, indent=indent, separators=separators), '\n'),
         mimetype='application/json')
     return rv
 

--- a/flask/json.py
+++ b/flask/json.py
@@ -248,8 +248,8 @@ def jsonify(*args, **kwargs):
     except:
         if current_app.config['JSONIFY_ALLOW_TOPLEVEL_ARRAY']:
             # Return a toplevel array when converting to an object
-            # is not possible
-            data = list(*args, **kwargs)
+            # is not possible and kwargs is empty
+            data = kwargs or args
         else:
             raise
 


### PR DESCRIPTION
Multiple issues including #248 call for `jsonify` to handle lists. As discussed there, allowing toplevel arrays should pose no security problem nowadays. A config parameter is added to enable this functionality, and an array is returned only when a conversion to an object is not possible to maintain backwards compatibility.

In short, when `JSONIFY_ALLOW_TOPLEVEL_ARRAY` is set, `jsonify(1, 2, 3)`, `jsonify(question='Ultimate', answer=42)`, and `jsonify({'question': 'Ultimate', 'answer': 42})` all work as expected.  Note that unlike dicts, `jsonify([1, 2, 3])` will result in nested lists, so always use `jsonify(*l)` for a list variable `l`.