### PR TITLE
fix bad autodoc signature when functions are decorated

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,8 @@ import sys, os
 sys.path.append(os.path.abspath('_themes'))
 sys.path.append(os.path.abspath('.'))
 
+os.environ['SPHINX_BUILD'] = '1'
+
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/flask/app.py
+++ b/flask/app.py
@@ -41,6 +41,9 @@ _logger_lock = Lock()
 # a singleton sentinel value for parameter defaults
 _sentinel = object()
 
+# Returns functions instead of decorators when building the documentation
+IS_SPHINX_BUILD = bool(os.getenv('SPHINX_BUILD'))
+
 
 def _make_timedelta(value):
     if not isinstance(value, timedelta):
@@ -62,7 +65,7 @@ def setupmethod(f):
                 'database models and everything related at a central place '
                 'before the application starts serving requests.')
         return f(self, *args, **kwargs)
-    return update_wrapper(wrapper_func, f)
+    return f if IS_SPHINX_BUILD else update_wrapper(wrapper_func, f)
 
 
 class Flask(_PackageBoundObject):


### PR DESCRIPTION
It's very annoying when you read the API documentation, all decorated functions haven't the correct signature.

Example : 

`errorhandler(*args, **kwargs)`

should be 

`errorhandler(code_or_exception)`


this PR fixes this issue with an elegant solution found here : https://github.com/praw-dev/praw/blob/master/praw/decorators.py
