### PR TITLE
JSON support for the Flask test client

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Development Lead
 Patches and Suggestions
 ```````````````````````
 
+- Adam Byrtek
 - Adam Zapletal
 - Ali Afshar
 - Chris Edgemon

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,9 @@ Version 1.0
 
 (release date to be announced, codename to be selected)
 
+- Added `json` keyword argument to :meth:`flask.testing.FlaskClient.open`
+  (and related ``get``, ``post``, etc.), which makes it more convenient to
+  send JSON requests from the test client.
 - Added `**kwargs` to :meth:`flask.Test.test_client` to support passing
   additional keyword arguments to the constructor of
   :attr:`flask.Flask.test_client_class`.

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -37,7 +37,7 @@ def make_test_environ_builder(app, path='/', base_url=None, json=None, *args, **
 
     if json is not None:
         if 'data' in kwargs:
-            raise RuntimeError('Client cannot provide both `json` and `data`')
+            raise ValueError('Client cannot provide both `json` and `data`')
         kwargs['data'] = json_dumps(json)
 
         # Only set Content-Type when not explicitly provided

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -35,16 +35,14 @@ def make_test_environ_builder(app, path='/', base_url=None, json=None, *args, **
             if url.query:
                 path += '?' + url.query
 
-    if json:
+    if json is not None:
         if 'data' in kwargs:
             raise RuntimeError('Client cannot provide both `json` and `data`')
         kwargs['data'] = json_dumps(json)
 
         # Only set Content-Type when not explicitly provided
-        if 'Content-Type' not in kwargs.get('headers', {}):
-            new_headers = kwargs.get('headers', {}).copy()
-            new_headers['Content-Type'] = 'application/json'
-            kwargs['headers'] = new_headers
+        if 'content_type' not in kwargs:
+            kwargs['content_type'] = 'application/json'
 
     return EnvironBuilder(path, base_url, *args, **kwargs)
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -221,6 +221,7 @@ def test_json_request():
         json_data = {'drink': {'gin': 1, 'tonic': True}, 'price': 10}
         rv = c.post('/api', json=json_data)
         assert rv.status_code == 200
+        assert flask.request.is_json
         assert flask.request.get_json() == json_data
 
 def test_subdomain():

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -209,6 +209,20 @@ def test_full_url_request():
         assert 'gin' in flask.request.form
         assert 'vodka' in flask.request.args
 
+def test_json_request():
+    app = flask.Flask(__name__)
+    app.testing = True
+
+    @app.route('/api', methods=['POST'])
+    def api():
+        return ''
+
+    with app.test_client() as c:
+        json_data = {'drink': {'gin': 1, 'tonic': True}, 'price': 10}
+        rv = c.post('/api', json=json_data)
+        assert rv.status_code == 200
+        assert flask.request.get_json() == json_data
+
 def test_subdomain():
     app = flask.Flask(__name__)
     app.config['SERVER_NAME'] = 'example.com'


### PR DESCRIPTION
This change adds support for JSON requests to the Flask test client, which makes testing JSON APIs much more convenient, and makes the arguments consistent with `request.data` and `request.json`.

Before:
```response = client.post('/url', data=json.dumps(json_data), content_type='application/json')```

After:
```response = client.post('/url', json=json_data})```

If this gets merged then I have another change to support `response.json`, which would make it easier to make assertions on JSON responses.