### PR TITLE
Allow custom jinja environments

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -157,6 +157,11 @@ class Flask(_PackageBoundObject):
     #: :class:`~flask.Response` for more information.
     response_class = Response
 
+    #: The class that is used for the Jinja environment.
+    #:
+    #: .. versionadded:: 0.11
+    jinja_env_class = Environment
+
     #: The class that is used for the :data:`~flask.g` instance.
     #:
     #: Example use cases for a custom class:
@@ -680,7 +685,7 @@ class Flask(_PackageBoundObject):
                 options['auto_reload'] = self.config['TEMPLATES_AUTO_RELOAD']
             else:
                 options['auto_reload'] = self.debug
-        rv = Environment(self, **options)
+        rv = self.jinja_env_class(self, **options)
         rv.globals.update(
             url_for=url_for,
             get_flashed_messages=get_flashed_messages,

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -361,3 +361,13 @@ def test_template_loader_debugging(test_apps):
             app.config['EXPLAIN_TEMPLATE_LOADING'] = old_load_setting
 
     assert len(called) == 1
+
+def test_custom_jinja_env():
+    class CustomEnvironment(flask.templating.Environment):
+        pass
+
+    class CustomFlask(flask.Flask):
+        jinja_env_class = CustomEnvironment
+
+    app = CustomFlask(__name__)
+    assert isinstance(app.jinja_env, CustomEnvironment)


### PR DESCRIPTION
This is useful e.g. when using the new Jinja Environment
attributes added in mitsuhiko/jinja2#404