### PR TITLE
Fix pep8 with logging

### DIFF
--- a/flask/logging.py
+++ b/flask/logging.py
@@ -57,10 +57,10 @@ def create_logger(app):
     Logger = getLoggerClass()
 
     class DebugLogger(Logger):
-        def getEffectiveLevel(x):
-            if x.level == 0 and app.debug:
+        def getEffectiveLevel(self):
+            if self.level == 0 and app.debug:
                 return DEBUG
-            return Logger.getEffectiveLevel(x)
+            return Logger.getEffectiveLevel(self)
 
     class DebugHandler(StreamHandler):
         def emit(self, record):


### PR DESCRIPTION
This should make the logging module more pep8 compatible. This PR fix problem issued in #1440 .

I made this PR to update first argument of class method in logging module from `x` to `self` in **master** branch. However, i can not make sure if i should at the same time make a PR to also clean the `logging` module in **0.10-maintenance**.

BTW, is the maintenance branch read-only(i checked out that last commit in **0.10-maintenance** is about years ago)? If so, what is the difference between a tag and this maintenance branch.