### PR TITLE
Mention that custom converters can be defined for url routes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -643,6 +643,8 @@ The following converters are available:
 `path`      like the default but also accepts slashes
 =========== ===============================================
 
+Custom converters can be defined using :attr:`flask.Flask.url_map`.
+
 Here are some examples::
 
     @app.route('/')


### PR DESCRIPTION
I had no idea about this for far too long. Adding this short sentence right after listing the built-in converters should go a long way to making this more clear for others, I think. I never stumbled across the (excellent) explanation under [`flask.Flask.url_map`](http://flask.pocoo.org/docs/0.10/api/#flask.Flask.url_map) before because the name `url_map` doesn't really indicate to me that you can learn about custom converters there.