### PR TITLE
importlib deprecated in 3.4

### DIFF
--- a/flask/config.py
+++ b/flask/config.py
@@ -9,8 +9,8 @@
     :license: BSD, see LICENSE for more details.
 """
 
-import imp
 import os
+import types
 import errno
 
 from werkzeug.utils import import_string
@@ -123,7 +123,7 @@ class Config(dict):
            `silent` parameter.
         """
         filename = os.path.join(self.root_path, filename)
-        d = imp.new_module('config')
+        d = types.ModuleType('config')
         d.__file__ = filename
         try:
             with open(filename) as config_file:

--- a/scripts/flaskext_compat.py
+++ b/scripts/flaskext_compat.py
@@ -15,9 +15,9 @@
     :copyright: (c) 2015 by Armin Ronacher.
     :license: BSD, see LICENSE for more details.
 """
+import types
 import sys
 import os
-import imp
 
 
 class ExtensionImporter(object):
@@ -118,7 +118,7 @@ class ExtensionImporter(object):
 
 def activate():
     import flask
-    ext_module = imp.new_module('flask.ext')
+    ext_module = types.ModuleType('flask.ext')
     ext_module.__path__ = []
     flask.ext = sys.modules['flask.ext'] = ext_module
     importer = ExtensionImporter(['flask_%s', 'flaskext.%s'], 'flask.ext')


### PR DESCRIPTION
Replace the use of importlib by types.ModuleType in 3.4+

closes gh-1449

Not sure how to make a test for it, either I need to monkeypatch stdlib, or have the tests run with `-W error` which I'm not sure how.