### PR TITLE
Add X-Forwarded-Proto header to proxy setup example docs

### DIFF
--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -97,9 +97,10 @@ localhost at port 8000, setting appropriate headers:
             proxy_pass         http://127.0.0.1:8000/;
             proxy_redirect     off;
 
-            proxy_set_header   Host             $host;
-            proxy_set_header   X-Real-IP        $remote_addr;
-            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   Host                 $host;
+            proxy_set_header   X-Real-IP            $remote_addr;
+            proxy_set_header   X-Forwarded-For      $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto    $scheme;
         }
     }
 


### PR DESCRIPTION
The `ProxyFix` middleware provided by Werkzeug uses this header for
returning accurate values from request.is_secure and request.scheme.
Without adding this header, Flask won't properly detect when it is being
served over HTTPS and will fail to generate proper external links and
cause certain extensions (e.g. Flask-OAuthlib) to function improperly.
Adding this header to the example setup should reduce issues encountered
by developers when following this guide.

Credit where due: I tend to find this information when I need it in a [blog post](http://cramer.io/2013/06/27/serving-python-web-applications/) by David Cramer.