### PR TITLE
config.from_pyfile() avoid UnicodeDecodeError

### DIFF
--- a/flask/config.py
+++ b/flask/config.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
+import io
 import os
 import types
 import errno
@@ -126,7 +127,7 @@ class Config(dict):
         d = types.ModuleType('config')
         d.__file__ = filename
         try:
-            with open(filename) as config_file:
+            with io.open(filename, "rb") as config_file:
                 exec(compile(config_file.read(), filename, 'exec'), d.__dict__)
         except IOError as e:
             if silent and e.errno in (errno.ENOENT, errno.EISDIR):


### PR DESCRIPTION
If the local variables (LC_*) are not properly configured, Python
use ASCII as the default encoding. This is fine and Flask works properly.

If the configuration file come with non ASCII caractere, an
UnicodeDecodeError exception will be raised as soon as read() will
try to decode the byte stream.

io.open() as been introduced in Py26 and the ability to specify
the encoding of the file. We use it to force the use of binary mode.