### PR TITLE
Add a method to register multiple blueprints at once.

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -931,6 +931,10 @@ class Flask(_PackageBoundObject):
             first_registration = True
         blueprint.register(self, options, first_registration)
 
+    def register_blueprints(self, blueprints):
+        for blueprint in blueprints:
+            self.register_blueprint(blueprint)
+
     def iter_blueprints(self):
         """Iterates over all blueprints by the order they were registered.
 


### PR DESCRIPTION
Hi, I added a method to register multiple blueprints.

#### Example
```python
app.register_blueprints([a_blueprint, b_blueprint, c_blueprint])
```

Thanks.