### PR TITLE
Change documentation entries

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -813,8 +813,9 @@ class _PackageBoundObject(object):
 
     @property
     def has_static_folder(self):
-        """This is ``True`` if the package bound object's container has a
-        folder named ``'static'``.
+        """This is ``True`` if the package bound object's container instance has
+        its attribute ``static_folder`` (defaults to ``'static'``) different
+        than ``None``.
 
         .. versionadded:: 0.5
         """

--- a/flask/json.py
+++ b/flask/json.py
@@ -85,7 +85,7 @@ class JSONEncoder(_json.JSONEncoder):
 
 class JSONDecoder(_json.JSONDecoder):
     """The default JSON decoder.  This one does not change the behavior from
-    the default simplejson encoder.  Consult the :mod:`json` documentation
+    the default simplejson decoder.  Consult the :mod:`json` documentation
     for more information.  This decoder is not only used for the load
     functions of this module but also :attr:`~flask.Request`.
     """


### PR DESCRIPTION
Specially misleading the entry about the `static` directory, as it can have another name and still be valid.