### PR TITLE
Implement config.from_envjson (with testing)

### DIFF
--- a/flask/config.py
+++ b/flask/config.py
@@ -213,6 +213,56 @@ class Config(dict):
                     self[key] = value
         return True
 
+    def from_envjson(self, prefix, silent=False):
+        """Updates the config from JSON-parsed environment variables.
+
+        For example::
+
+            $ export FLASKR_DEBUG='true'
+            $ export FLASKR_SECRET_KEY='"ba92ffd4d9582827cb8f93c4b48f60e3"'
+            $ export FLASKR_MAX_CONTENT_LENGTH='4096'
+            $ cat <<EOF > foo.py
+            > from flask import Flask
+            >
+            > app = Flask(__name__)
+            > app.config.from_envjson('FLASKR')
+            >
+            > print('DEBUG:%r' % app.debug)
+            > print('SECRET_KEY:%r' app.secret_key)
+            > print('MAX_CONTENT_LENGTH:%r' % app.config['MAX_CONTENT_LENGTH'])
+            > EOF
+            $ python foo.py
+            DEBUG:True
+            SECRET_KEY:'ba92ffd4d9582827cb8f93c4b48f60e3'
+            MAX_CONTENT_LENGTH:4096
+
+        :param prefix: the prefix to specify which variables to be imported.
+                       (e.g. ``FLASKR``)
+        :param silent: set to ``True`` if you want to ignore some environment
+                       variables which could not be parsed as JSON expression
+                       instead of raising a :exc:`ValueError`.
+
+        .. versionadded:: 1.0
+        """
+        for name, value in iteritems(os.environ):
+            if not name.startswith(prefix):
+                continue
+            try:
+                config_value = json.loads(value)
+            except ValueError:
+                if silent:
+                    continue
+                error_msg = (
+                    '{0}={1!r} found but it is unable to parse {1!r} as a '
+                    'JSON expression.\n\n'
+                    'You may need to write {0}=\'"{1}"\' in shell if the '
+                    'value should be string type.')
+                raise ValueError(error_msg.format(name, value))
+            else:
+                config_name = name[len(prefix):]  # strips prefix
+                config_name = config_name.lstrip('_')  # strips possible "_"
+                self[config_name] = config_value
+
     def get_namespace(self, namespace, lowercase=True, trim_namespace=True):
         """Returns a dictionary containing a subset of configuration options
         that match the specified namespace/prefix. Example usage::

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -150,6 +150,55 @@ def test_config_missing_json():
     assert not app.config.from_json('missing.json', silent=True)
 
 
+def test_config_from_envjson():
+    env = os.environ
+    try:
+        os.environ = {'FOO_BAR_BOOLEAN': 'true', 'FOO_BAR_STRING': '"true"',
+                      'FOO_BAR_INTEGER': '42', 'FOO_BAR_FLOAT': '3.14',
+                      'FOO_BAR_LIST': '[1,2,3]', 'FOO_BAR_DICT': '{"1": 2}'}
+
+        def assert_config_correct(app):
+            assert app.config['BAR_BOOLEAN'] is True
+            assert app.config['BAR_STRING'] == 'true'
+            assert app.config['BAR_INTEGER'] == 42
+            assert app.config['BAR_FLOAT'] == 3.14
+            assert app.config['BAR_LIST'] == [1, 2, 3]
+            assert app.config['BAR_DICT'] == {'1': 2}
+
+        # without underline
+        app = flask.Flask(__name__)
+        app.config.from_envjson('FOO')
+        assert_config_correct(app)
+
+        # with underline
+        app = flask.Flask(__name__)
+        app.config.from_envjson('FOO_')
+        assert_config_correct(app)
+    finally:
+        os.environ = env
+
+
+def test_config_from_envjson_invalid():
+    env = os.environ
+    try:
+        os.environ = {'FOO_BAR_BOOLEAN': 'true', 'FOO_BAR_INVALID': 'garbage'}
+
+        # silent:False - exception raised
+        app = flask.Flask(__name__)
+        with pytest.raises(ValueError) as einfo:
+            app.config.from_envjson('FOO')
+        assert "FOO_BAR_INVALID='garbage' found" in einfo.value.args[0]
+        assert "FOO_BAR_INVALID='\"garbage\"' in shell" in einfo.value.args[0]
+
+        # silent:True - invalid value ignored
+        app = flask.Flask(__name__)
+        app.config.from_envjson('FOO', silent=True)
+        assert app.config['BAR_BOOLEAN'] is True
+        assert 'BAR_INVALID' not in app.config
+    finally:
+        os.environ = env
+
+
 def test_custom_config_class():
     class Config(flask.Config):
         pass


### PR DESCRIPTION
I added a new method `from_envjson` into `Config` class. It allows people to configure their applications with environment variables in JSON syntax, without any config file.

Storing config in environment variables is a recommended practice of [12-Factor App](http://12factor.net/config). It is supported by many development and deployment utilities, including systemd(`EnvironmentFile` field in service file), [honcho](https://github.com/nickstenning/honcho), [autoenv](https://github.com/kennethreitz/autoenv) and more.

Please review it. Thanks.