### PR TITLE
DRY globals definition

### DIFF
--- a/flask/globals.py
+++ b/flask/globals.py
@@ -45,17 +45,14 @@ def _lookup_app_object(name):
     return getattr(top, name)
 
 
-def _find_app():
-    top = _app_ctx_stack.top
-    if top is None:
-        raise RuntimeError(_app_ctx_err_msg)
-    return top.app
+def _proxy_attr(fn, name):
+    return LocalProxy(partial(fn, name))
 
 
 # context locals
 _request_ctx_stack = LocalStack()
 _app_ctx_stack = LocalStack()
-current_app = LocalProxy(_find_app)
-request = LocalProxy(partial(_lookup_req_object, 'request'))
-session = LocalProxy(partial(_lookup_req_object, 'session'))
-g = LocalProxy(partial(_lookup_app_object, 'g'))
+current_app = _proxy_attr(_lookup_app_object, 'app')
+g = _proxy_attr(_lookup_app_object, 'g')
+request = _proxy_attr(_lookup_req_object, 'request')
+session = _proxy_attr(_lookup_req_object, 'session')


### PR DESCRIPTION
Hi there,

Changed a little the globals.py file to avoid some code repetition, and also changed the order. The main change in my opinion is that now the `current_app` proxy would use `return getattr(top, 'app')` instead of `return top.app`. Maybe this has some side effects which I am missing.