### PR TITLE
Remove mention of abandoned project Flask-Uploads from docs

### DIFF
--- a/docs/patterns/fileuploads.rst
+++ b/docs/patterns/fileuploads.rst
@@ -104,9 +104,9 @@ before storing it directly on the filesystem.
    >>> secure_filename('../../../../home/username/.bashrc')
    'home_username_.bashrc'
 
-Now one last thing is missing: the serving of the uploaded files. In the 
-:func:`upload_file()` we redirect the user to 
-``url_for('uploaded_file', filename=filename)``, that is, ``/uploads/filename``. 
+Now one last thing is missing: the serving of the uploaded files. In the
+:func:`upload_file()` we redirect the user to
+``url_for('uploaded_file', filename=filename)``, that is, ``/uploads/filename``.
 So we write the :func:`uploaded_file` function to return the file of that name. As
 of Flask 0.5 we can use a function that does that for us::
 
@@ -174,11 +174,3 @@ An Easier Solution
 Now there are better solutions that work faster and are more reliable. There
 are JavaScript libraries like jQuery_ that have form plugins to ease the
 construction of progress bar.
-
-Because the common pattern for file uploads exists almost unchanged in all
-applications dealing with uploads, there is also a Flask extension called
-`Flask-Uploads`_ that implements a full fledged upload mechanism with white and
-blacklisting of extensions and more.
-
-.. _jQuery: https://jquery.com/
-.. _Flask-Uploads: http://pythonhosted.org/Flask-Uploads/

--- a/docs/patterns/fileuploads.rst
+++ b/docs/patterns/fileuploads.rst
@@ -174,3 +174,5 @@ An Easier Solution
 Now there are better solutions that work faster and are more reliable. There
 are JavaScript libraries like jQuery_ that have form plugins to ease the
 construction of progress bar.
+
+.. _jQuery: https://jquery.com/


### PR DESCRIPTION
I would love to see this project updated, but it seems to have been abandoned by its creator. Still doesn't support Python 3 and hasn't given any love to PyPI for almost 4 years. It seems impossible to get in contact with the creator. This PR removes the reference of `Flask-Uploads` from the docs. Another option would be to have a NOTE about it being abandoned. I think it also makes sense to remove it from the [Flask extensions list](http://flask.pocoo.org/extensions/) (where's the repo for that?)

[Here's a 2 year old ticket on Bitbucket that fixes Python 3 support](https://bitbucket.org/leafstorm/flask-uploads/pull-request/5/modernizing/diff). No reply what-so-ever from @leafstorm. His last public activity on Bitbucket was three years ago.

I'll e-mail him with a reference to this ticket to see if we can get a reply. Perhaps with this ticket we can get the project owner's attention.

The best alternative would of course be to get development going on the project again, perhaps by adding more contributors to the project. Let me know how you feel about all of this. :blush: