### PR TITLE
fix UnboundLocalError in handle_url_build_error

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1769,8 +1769,9 @@ class Flask(_PackageBoundObject):
                 rv = handler(error, endpoint, values)
                 if rv is not None:
                     return rv
-            except BuildError as error:
-                pass
+            except BuildError as e:
+                # make error available outside except block (py3)
+                error = e
 
         # At this point we want to reraise the exception.  If the error is
         # still the same one we can reraise it with the original traceback,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1067,6 +1067,16 @@ def test_build_error_handler():
     app.url_build_error_handlers.append(handler)
     with app.test_request_context():
         assert flask.url_for('spam') == '/test_handler/'
+    # remove handler after test
+    app.url_build_error_handlers.pop()
+
+    # Test a custom handler which reraises the BuildError
+    def handler_raises_build_error(error, endpoint, values):
+        raise error
+    app.url_build_error_handlers.append(handler_raises_build_error)
+    app.config['SERVER_NAME'] = 'unit.test'  # SERVER_NAME is required in this case, is this correct?
+    with app.app_context():
+        pytest.raises(BuildError, flask.url_for, 'not.existing')
 
 
 def test_custom_converters():


### PR DESCRIPTION
- caused by changes in the execution model of python 3 where the alias of an except clause is cleared on exit of the except

- tested with python 2.7.10 and 3.4.3