### PR TITLE
make external_url_handler example py3 compliant

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -219,7 +219,7 @@ def url_for(endpoint, **values):
                 # Re-raise the BuildError, in context of original traceback.
                 exc_type, exc_value, tb = sys.exc_info()
                 if exc_value is error:
-                    raise exc_type, exc_value, tb
+                    raise exc_type(exc_value, endpoint, values).with_traceback(tb)
                 else:
                     raise error
             # url_for will use this result, instead of raising BuildError.


### PR DESCRIPTION
- a raises statement with multiple values is no longer allowed in python 3
- It's just a documentation change, no functionality changed.