### PR TITLE
Revert "make external_url_handler example py3 compliant"

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -219,7 +219,7 @@ def url_for(endpoint, **values):
                 # Re-raise the BuildError, in context of original traceback.
                 exc_type, exc_value, tb = sys.exc_info()
                 if exc_value is error:
-                    raise exc_type(exc_value, endpoint, values).with_traceback(tb)
+                    raise exc_type, exc_value, tb
                 else:
                     raise error
             # url_for will use this result, instead of raising BuildError.


### PR DESCRIPTION
Sorry, i should have tested this first and not rely on my IDE.

Actually in python 2.7 this causes `AttributeError: 'BuildError' object has no attribute 'with_traceback'`

Therefore this has to be reverted.

Reverts mitsuhiko/flask#1534