### PR TITLE
Improve function with_metaclass()

### DIFF
--- a/flask/_compat.py
+++ b/flask/_compat.py
@@ -54,15 +54,14 @@ else:
 
 
 def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
     # This requires a bit of explanation: the basic idea is to make a
     # dummy metaclass for one level of class instantiation that replaces
     # itself with the actual metaclass.
-    #
-    # This has the advantage over six.with_metaclass in that it does not
-    # introduce dummy classes into the final MRO.
-    constructor = lambda c, name, b, dct: meta(name, bases, dct)
-    metaclass = type('with_metaclass', (type,), {'__new__': constructor})
-    return type.__new__(metaclass, 'temporary_class', (object,), {})
+    class metaclass(type):
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+    return type.__new__(metaclass, 'temporary_class', (), {})
 
 
 # Certain versions of pypy have a bug where clearing the exception stack

--- a/flask/_compat.py
+++ b/flask/_compat.py
@@ -56,21 +56,13 @@ else:
 def with_metaclass(meta, *bases):
     # This requires a bit of explanation: the basic idea is to make a
     # dummy metaclass for one level of class instantiation that replaces
-    # itself with the actual metaclass.  Because of internal type checks
-    # we also need to make sure that we downgrade the custom metaclass
-    # for one level to something closer to type (that's why __call__ and
-    # __init__ comes back from type etc.).
+    # itself with the actual metaclass.
     #
     # This has the advantage over six.with_metaclass in that it does not
     # introduce dummy classes into the final MRO.
-    class metaclass(meta):
-        __call__ = type.__call__
-        __init__ = type.__init__
-        def __new__(cls, name, this_bases, d):
-            if this_bases is None:
-                return type.__new__(cls, name, (), d)
-            return meta(name, bases, d)
-    return metaclass('temporary_class', None, {})
+    constructor = lambda c, name, b, dct: meta(name, bases, dct)
+    metaclass = type('with_metaclass', (type,), {'__new__': constructor})
+    return type.__new__(metaclass, 'temporary_class', (object,), {})
 
 
 # Certain versions of pypy have a bug where clearing the exception stack


### PR DESCRIPTION
The idea of a metaclass *"that replaces itself with the actual metaclass"* is really clever. Yet I cannot help but suspect that the current implementation of function `with_metaclass` is just a bit too much.

Why does the dummy metaclass extend the one to apply?

It never utilizes any of the base class' resources, except for the base class itself. Since this is done by direct invocation (not via `super()` or something), there should be no need to inherit from the caller-provided type in the first place.

Furthermore, given that the above obvservation is correct, there should be no need to explicitly utilize `type.__call__` and `type.__init__` any more. Not only because one can directly inherit from `type` here, but also because both seem to be required due to the aforementioned inheritance only: If the given `meta` class implements custom magic, the creation of the `temporary_class` could fail. Or even worse; succeed but silently misinterprete arguments.

Speaking of the `temporary_class` creation (and still assuming all of the above assumptions to be correct): There's no need to do that via the `metaclass` constructor at all, which actually saves not only the additional function call but also the condition within `__new__`.

Given I didn't miss something (and there is indeed no actual reason for the metaclass to extend the one to apply), then I believe the patch suggested with this pull request to significantly improve the code without changing any of the expected behavior.