### PR TITLE
travis: python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "pypy"
   - "3.3"
   - "3.4"
+  - "3.5"
 
 env:
   - REQUIREMENTS=lowest
@@ -19,6 +20,8 @@ matrix:
     - python: "3.3"
       env: REQUIREMENTS=lowest
     - python: "3.4"
+      env: REQUIREMENTS=lowest
+    - python: "3.5"
       env: REQUIREMENTS=lowest
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,pypy}-{lowest,release,devel}, {py33,py34}-{release,devel}
+envlist = {py26,py27,pypy}-{lowest,release,devel}, {py33,py34,py35}-{release,devel}
 
 [testenv]
 commands =


### PR DESCRIPTION
Add python 3.5 build to travis configuration.