### PR TITLE
Render the code block in mongokit.rst

### DIFF
--- a/docs/patterns/mongokit.rst
+++ b/docs/patterns/mongokit.rst
@@ -48,6 +48,7 @@ insert query to the next without any problem.  MongoKit is just schemaless
 too, but implements some validation to ensure data integrity.
 
 Here is an example document (put this also into :file:`app.py`, e.g.)::
+
     from mongokit import ValidationError
 
     def max_length(length):


### PR DESCRIPTION
The code block in [mongokit pattern](http://flask.pocoo.org/docs/dev/patterns/mongokit/#declarative) seems not rendered properly. Fix it by adding the missing blank line.