### PR TITLE
Looks like pytest is not the only minimal dependency

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -38,10 +38,10 @@ Running the testsuite
 You probably want to set up a `virtualenv
 <http://virtualenv.readthedocs.org/en/latest/index.html>`_.
 
-The minimal requirement for running the testsuite is ``py.test``.  You can
-install it with::
+The minimal requirement for running the testsuite is ``py.test`` and ``redbaron``.  You can
+install them with the following command::
 
-    pip install pytest
+    pip install pytest redbaron
 
 Clone this repository::
 


### PR DESCRIPTION
With a fresh clone of the project.
By just installing pytest this is what i get when i run ``py.test``:

```
____ERROR collecting scripts/test_import_migration.py ___
scripts/test_import_migration.py:5: in <module>
    from redbaron import RedBaron
E   ImportError: No module named 'redbaron'
```