### PR TITLE
Add .cache dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 *.egg-info
 _mailinglist
 .tox
+.cache/


### PR DESCRIPTION
I think this could be handy and potentially minimise the risk
anyone commits it to the project.

```
flask - (master) $ tree .cache/
.cache/
└── v
    └── cache
        └── lastfailed

```