### PR TITLE
Allow application configurations to control the debugger

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -105,6 +105,15 @@ class DispatchingApp(object):
     of the Werkzeug debugger means that it shows up in the browser.
     """
 
+    @property
+    def debug(self):
+        try:
+            return self._app.debug
+        except AttributeError as e:
+            print('Application not created yet, can\'t determine debug '
+                  'status.')
+            return False
+
     def __init__(self, loader, use_eager_loading=False):
         self.loader = loader
         self._app = None
@@ -420,6 +429,10 @@ def run_command(info, host, port, reload, debugger, eager_loading,
             print(' * Serving Flask app "%s"' % info.app_import_path)
         if info.debug is not None:
             print(' * Forcing debug %s' % (info.debug and 'on' or 'off'))
+
+    if app.debug:
+        debugger = True
+        print(' * Debug activated by application configuration.')
 
     run_simple(host, port, app, use_reloader=reload,
                use_debugger=debugger, threaded=with_threads)


### PR DESCRIPTION
I was surprised when running my application from the CLI that it didn't respect the applications debug flag.  This patch expands `DispatchApp`'s api to return the applications debug flag which is used by `run_simple` to activate the debugger and supply an informative message.

I explored enabling the reloader along with enabling the debugger but that caused a double execution. If I understand it correctly, the double load is the result of `eager_loading` not being switched properly because the reload status (if activated by the applications debug flag) wouldn't be known until after loading has occurred.

Since I am not positive what side-effects (none to my limited understanding) double execution would have I left that code out; it is a trivial addition if a double execution is acceptable in this case.