### PR TITLE
0.10 maintenance

### DIFF
--- a/flask/testsuite/test_apps/config_module_app.py
+++ b/flask/testsuite/test_apps/config_module_app.py
@@ -1,4 +1,4 @@
 import os
 import flask
 here = os.path.abspath(os.path.dirname(__file__))
-app = flask.Flask(__name__,instance_path=os.path.join(os.path.abspath(os.path.dirname(__file__)),'instance'))
+app = flask.Flask(__name__, instance_path=os.path.join(os.path.abspath(os.path.dirname(__file__)),'instance'))

--- a/flask/testsuite/test_apps/config_module_app.py
+++ b/flask/testsuite/test_apps/config_module_app.py
@@ -1,4 +1,4 @@
 import os
 import flask
 here = os.path.abspath(os.path.dirname(__file__))
-app = flask.Flask(__name__)
+app = flask.Flask(__name__,instance_path=os.path.join(os.path.abspath(os.path.dirname(__file__)),'instance'))

--- a/flask/testsuite/test_apps/config_package_app/__init__.py
+++ b/flask/testsuite/test_apps/config_package_app/__init__.py
@@ -1,4 +1,4 @@
 import os
 import flask
 here = os.path.abspath(os.path.dirname(__file__))
-app = flask.Flask(__name__,instance_path=os.path.join(os.path.abspath(os.path.dirname(os.path.dirname(__file__))),'instance'))
+app = flask.Flask(__name__, instance_path=os.path.join(os.path.abspath(os.path.dirname(os.path.dirname(__file__))),'instance'))

--- a/flask/testsuite/test_apps/config_package_app/__init__.py
+++ b/flask/testsuite/test_apps/config_package_app/__init__.py
@@ -1,4 +1,4 @@
 import os
 import flask
 here = os.path.abspath(os.path.dirname(__file__))
-app = flask.Flask(__name__)
+app = flask.Flask(__name__,instance_path=os.path.join(os.path.abspath(os.path.dirname(os.path.dirname(__file__))),'instance'))

--- a/flask/testsuite/test_apps/main_app.py
+++ b/flask/testsuite/test_apps/main_app.py
@@ -1,3 +1,4 @@
+import os
 import flask
 
 # Test Flask initialization with main module.

--- a/flask/testsuite/test_apps/main_app.py
+++ b/flask/testsuite/test_apps/main_app.py
@@ -2,4 +2,4 @@ import os
 import flask
 
 # Test Flask initialization with main module.
-app = flask.Flask('__main__',instance_path=os.path.join(os.path.abspath(os.path.dirname('__main__')),'instance'))
+app = flask.Flask('__main__', instance_path=os.path.join(os.path.abspath(os.path.dirname('__main__')),'instance'))

--- a/flask/testsuite/test_apps/main_app.py
+++ b/flask/testsuite/test_apps/main_app.py
@@ -1,4 +1,4 @@
 import flask
 
 # Test Flask initialization with main module.
-app = flask.Flask('__main__')
+app = flask.Flask('__main__',instance_path=os.path.join(os.path.abspath(os.path.dirname('__main__')),'instance'))


### PR DESCRIPTION
Made changes regarding to instance path of files in flask/testsuite/test_apps

While running test case by run-test.py module it causes Error for instance path.
```sh
FAIL: test_main_module_paths (flask.testsuite.config.InstanceTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "../flaskenv/flask/flask/testsuite/config.py", line 157, in test_main_module_paths
    self.assert_equal(app.instance_path, os.path.join(here, 'instance'))

  File "../flaskenv/flask/flask/testsuite/__init__.py", line 141, in assert_equal
    return self.assertEqual(x, y)

AssertionError: '../flaskenv/var/run-tests-instance' != '../flaskenv/flask/instance'
- ../flaskenv/var/run-tests-instance
?             ^ ^ ----------
+ ../flaskenv/flask/instance
?             ^^ ^^
```

```sh
FAIL: test_uninstalled_module_paths (flask.testsuite.config.InstanceTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "../flaskenv/flask/flask/testsuite/config.py", line 164, in test_uninstalled_module_paths
    self.assert_equal(app.instance_path, os.path.join(here, 'test_apps', 'instance'))

  File "../flaskenv/flask/flask/testsuite/__init__.py", line 141, in assert_equal
    return self.assertEqual(x, y)

AssertionError: '/hom[23 chars]ang-py3-test/flaskenv/var/config_module_app-instance' != '/hom[23 chars]ang-py3-test/flaskenv/flask/flask/testsuite/test_apps/instance'
- ../flaskenv/var/config_module_app-instance
?             ^ ^ ---  ^^^^^^^     ^
+ ../flaskenv/flask/flask/testsuite/test_apps/instance
?             ^^ ^^  +++++++++++ ^ +++++    ^^
```

```sh
FAIL: test_uninstalled_package_paths (flask.testsuite.config.InstanceTestCase)
\----------------------------------------------------------------------
Traceback (most recent call last):
  File "../flaskenv/flask/flask/testsuite/config.py", line 169, in test_uninstalled_package_paths
    self.assert_equal(app.instance_path, os.path.join(here, 'test_apps', 'instance'))

  File "../flaskenv/flask/flask/testsuite/__init__.py", line 141, in assert_equal
    return self.assertEqual(x, y)

AssertionError: '/hom[23 chars]ang-py3-test/flaskenv/var/config_package_app-instance' != '/hom[23 chars]ang-py3-test/flaskenv/flask/flask/testsuite/test_apps/instance'
- ../flaskenv/var/config_package_app-instance
?             ^ ^ ---  ^^^^^^^^     ^
+ ../flaskenv/flask/flask/testsuite/test_apps/instance
?             ^^ ^^  +++++++++++ ^ +++++    ^^

----------------------------------------------------------------------
Ran 226 tests in 4.574s

FAILED (failures=3)
```

Changes In the following files remove this instance path Error from the Test case:
- flask/testsuite/test_apps/config_module_app.py.
- flask/testsuite/test_apps/config_package_app/__init__.py.
- flask/testsuite/test_apps/main_app.py

