### PR TITLE
Mod wsgi docs

### DIFF
--- a/docs/deploying/mod_wsgi.rst
+++ b/docs/deploying/mod_wsgi.rst
@@ -116,6 +116,20 @@ Note: There have been some changes in access control configuration for `Apache 2
 
 .. _Apache 2.4: http://httpd.apache.org/docs/trunk/upgrading.html
 
+Most notably, the syntax for directory permissions has changed from httpd 2.2
+
+.. sourcecode:: apache
+
+    Order allow,deny
+    Allow from all
+
+to httpd 2.4 syntax
+
+.. sourcecode:: apache
+
+    Require all granted
+
+
 For more information consult the `mod_wsgi wiki`_.
 
 .. _mod_wsgi: http://code.google.com/p/modwsgi/


### PR DESCRIPTION
Updated the docs to include a an example of using httpd2.4 syntax for setting directory permissions.
There was a link  to Apache 2.4 but no explanation of changes needing to be made.

This was mentioned in issue #1644 

**Changes:**

update directory permissions from httpd 2.2 syntax 
```
    Order allow,deny
    Allow from all
```

to httpd 2.4 syntax
```
    Require all granted
```