### PR TITLE
Remove with_statement in flask/ctx.py

### DIFF
--- a/flask/ctx.py
+++ b/flask/ctx.py
@@ -9,8 +9,6 @@
     :license: BSD, see LICENSE for more details.
 """
 
-from __future__ import with_statement
-
 import sys
 from functools import update_wrapper
 


### PR DESCRIPTION
It seems that we don't support 2.5 any more, and the with statement is mandatory since 2.6, I think we could remove it now.