### PR TITLE
Clarify the python versions that flask supports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,13 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],


### PR DESCRIPTION
I asked the question that whether we should explicitly point out the python versions flask supports in #1651 , and since it makes sense that we'd better clarify the versions, I send this PR.