### PR TITLE
Use indexation instead of slicing for getting the first element.

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -270,7 +270,7 @@ def url_for(endpoint, **values):
         url_adapter = reqctx.url_adapter
         blueprint_name = request.blueprint
         if not reqctx.request._is_old_module:
-            if endpoint[:1] == '.':
+            if endpoint[0] == '.':
                 if blueprint_name is not None:
                     endpoint = blueprint_name + endpoint
                 else:


### PR DESCRIPTION
It's less confusing and it's slightly faster:
```sh
$ python2.7 -m timeit -s 'foo="a"*1024' 'foo[:1]'
10000000 loops, best of 3: 0.0352 usec per loop
$ python2.7 -m timeit -s 'foo="a"*1024' 'foo[0]'
10000000 loops, best of 3: 0.0291 usec per loop
```
```sh
$ python3.4 -m timeit -s 'foo="a"*1024' 'foo[:1]'
10000000 loops, best of 3: 0.0473 usec per loop
$ python3.4 -m timeit -s 'foo="a"*1024' 'foo[0]'
10000000 loops, best of 3: 0.0302 usec per loop
```