### PR TITLE
terminate running port by application in case of exit process

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -779,6 +779,30 @@ class Flask(_PackageBoundObject):
             rv.update(processor())
         return rv
 
+    def reboot(self):
+        """A decorator that is used to terminate running port
+        by application.
+
+            @app.reboot()
+            @app.route('/')
+            def index():
+                return 'Hello World'
+
+        """
+        def decorator(f):
+            import re
+            import commands
+            s = commands.getoutput('lsof -i :5000')
+            try:
+                p_id = re.findall('.*?Python\s+[0-9]{4,7}', s)[0].split(' ')[-1]
+            except IndexError:
+                p_id = None
+            p_id = int(p_id) if p_id else None
+            if p_id:
+                commands.getoutput('kill -9 {}'.format(p_id))
+            return f
+        return decorator
+
     def run(self, host=None, port=None, debug=None, **options):
         """Runs the application on a local development server.  If the
         :attr:`debug` flag is set the server will automatically reload


### PR DESCRIPTION
I have noticed that it would be better to have such a simple tool as decorator in code base to terminate port running by app.

A simple example:

```
from flask import Flask

app = Flask(__name__)

@app.reboot()
@app.route("/")
def hello():
    return "Hello world"

if __name__ == "__main__":
    app.run()
```