### PR TITLE
Fix typo

### DIFF
--- a/docs/reqcontext.rst
+++ b/docs/reqcontext.rst
@@ -69,7 +69,7 @@ find a piece of code that looks very much like this::
         with self.request_context(environ):
             try:
                 response = self.full_dispatch_request()
-            except Exception, e:
+            except Exception as e:
                 response = self.make_response(self.handle_exception(e))
             return response(environ, start_response)
 

--- a/flask/app.py
+++ b/flask/app.py
@@ -421,7 +421,7 @@ class Flask(_PackageBoundObject):
         #: A dictionary with lists of functions that should be called after
         #: each request.  The key of the dictionary is the name of the blueprint
         #: this function is active for, ``None`` for all requests.  This can for
-        #: example be used to open database connections or getting hold of the
+        #: example be used to close database connections or getting hold of the
         #: currently logged in user.  To register a function here, use the
         #: :meth:`after_request` decorator.
         self.after_request_funcs = {}

--- a/flask/app.py
+++ b/flask/app.py
@@ -421,9 +421,8 @@ class Flask(_PackageBoundObject):
         #: A dictionary with lists of functions that should be called after
         #: each request.  The key of the dictionary is the name of the blueprint
         #: this function is active for, ``None`` for all requests.  This can for
-        #: example be used to close database connections or getting hold of the
-        #: currently logged in user.  To register a function here, use the
-        #: :meth:`after_request` decorator.
+        #: example be used to close database connections. To register a function
+        #: here, use the :meth:`after_request` decorator.
         self.after_request_funcs = {}
 
         #: A dictionary with lists of functions that are called after
@@ -791,8 +790,7 @@ class Flask(_PackageBoundObject):
 
         It is not recommended to use this function for development with
         automatic reloading as this is badly supported.  Instead you should
-        be using the :command:`flask` command line script's ``runserver``
-        support.
+        be using the :command:`flask` command line script's ``run`` support.
 
         .. admonition:: Keep in Mind
 

--- a/flask/config.py
+++ b/flask/config.py
@@ -222,7 +222,7 @@ class Config(dict):
             app.config['IMAGE_STORE_BASE_URL'] = 'http://img.website.com'
             image_store_config = app.config.get_namespace('IMAGE_STORE_')
 
-        The resulting dictionary `image_store` would look like::
+        The resulting dictionary `image_store_config` would look like::
 
             {
                 'type': 'fs',


### PR DESCRIPTION
* Use the compatible way to handle the exception. You can find the
source code wsgi_app in app.py, and it use the compatible way, so update it
* Fix typo in config.py
* Fix typo in app.py

---

One more question, in the [flask.Flask.run](http://flask.pocoo.org/docs/dev/api/#flask.Flask.run) documentation, it says:

> It is not recommended to use this function for development with automatic reloading as this is badly supported. Instead you should be using the flask command line script’s runserver support.

I guess it should be:

> ...the flask command line script’s run support.

since flask cli has the `run` command not the `runserver` command.