### PR TITLE
Update deprecated references

### DIFF
--- a/docs/patterns/wtforms.rst
+++ b/docs/patterns/wtforms.rst
@@ -32,11 +32,11 @@ This is an example form for a typical registration page::
         username = StringField('Username', [validators.Length(min=4, max=25)])
         email = StringField('Email Address', [validators.Length(min=6, max=35)])
         password = PasswordField('New Password', [
-            validators.Required(),
+            validators.DataRequired(),
             validators.EqualTo('confirm', message='Passwords must match')
         ])
         confirm = PasswordField('Repeat Password')
-        accept_tos = BooleanField('I accept the TOS', [validators.Required()])
+        accept_tos = BooleanField('I accept the TOS', [validators.DataRequired()])
 
 In the View
 -----------


### PR DESCRIPTION
validators.Required() is marked as deprecated in favor of validators.DataRequired() and will be remove in WTForms 3.