### PR TITLE
Run bdist_wheel as a part of release process

### DIFF
--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -86,7 +86,7 @@ def set_setup_version(version):
 
 
 def build_and_upload():
-    Popen([sys.executable, 'setup.py', 'release', 'sdist', 'upload']).wait()
+    Popen([sys.executable, 'setup.py', 'release', 'sdist', 'bdist_wheel', 'upload']).wait()
 
 
 def fail(message, *args):


### PR DESCRIPTION
The setup.cfg declares the ability to compile a wheel, but release process isn't actually compiling a wheel.